### PR TITLE
Fix sum builtin function to support arrays.

### DIFF
--- a/BUILTINS.md
+++ b/BUILTINS.md
@@ -2,6 +2,7 @@
 
 NovaScript has many builtin functions that offer easier usage of general functions in everyday programming.
 
+> [!WARNING]
 > All outputs displayed here are outputs in Release print. If you are creating outputs in Debug print, then the outputs will
 > be the entire runtime value object. See the below output example for `print("hello world")`.
 > 
@@ -50,17 +51,22 @@ Sat Jan 11 2025 16:01:04 GMT+0100 (Central European Standard Time)
 
 ## Math
 
-- ### `sum(numA, numB, ...)`
+- ### `sum(numA, numB, ... | numArr[])`
 
 The `sum()` function returns the calculated sum of all args passed in the function.
-Works only for numeric literals.
+Works only for numeric literals. Calculates the sum of Numeric Literals in the array if passed
+as an arg.
 
 ```javascript
 print(sum(1,2,3,4))
+
+const foo = [5,5,5,5,5];
+print(sum(foo))
 ```
 **Output:**
 ```text
 10
+25
 ```
 
 - ### `pow(base, power)`

--- a/BUILTINS.md
+++ b/BUILTINS.md
@@ -53,8 +53,7 @@ Sat Jan 11 2025 16:01:04 GMT+0100 (Central European Standard Time)
 - ### `sum(numA, numB, ...)`
 
 The `sum()` function returns the calculated sum of all args passed in the function.
-Works only for numeric literals. When arrays are supported in NovaScript, the function definition
-will be modified.
+Works only for numeric literals.
 
 ```javascript
 print(sum(1,2,3,4))

--- a/README.md
+++ b/README.md
@@ -295,3 +295,4 @@ The below items are TODOs that can be added to the language to increase its supp
 - ✅ Add escape sequences for strings.
 - 🔥Add import statements from other NovaScript files.
 - 🔥BinaryExpr update for `&&`, `||`, `!`.
+- 🔥 Operations on arrays as builtins.

--- a/file.nv
+++ b/file.nv
@@ -1,3 +1,4 @@
-const foo = "this is a str\ning";
+const foo = [1,2,3,4,5];
 
 print(foo)
+print(sum(foo))

--- a/frontend/test.ts
+++ b/frontend/test.ts
@@ -1,0 +1,3 @@
+const foo = [1,2,3,4];
+
+console.log()

--- a/frontend/test.ts
+++ b/frontend/test.ts
@@ -1,3 +1,0 @@
-const nums: number[] = [1,2,3,4,55,6,7,8,9];
-
-console.log(Math.max(...nums));

--- a/runtime/native-builtins.ts
+++ b/runtime/native-builtins.ts
@@ -52,6 +52,17 @@ export function randInt(_args: RuntimeVal[], _env: Environment): RuntimeVal {
 export function sumFunction(_args: RuntimeVal[], _env: Environment): RuntimeVal {
     let total: number = 0;
 
+    if (_args[0].type == "array"){
+        const numArray: RuntimeVal[] = (_args[0] as ArrayVal).values;
+
+        for (const rVal of numArray){
+            const nVal = rVal as NumberVal;
+            total += nVal.value;
+        }
+
+        return MK_NUMBER(total);
+    }
+
     for (const nval of _args){
         total += (nval as NumberVal).value;
     }


### PR DESCRIPTION
`sum()` now works with NovaScript arrays.